### PR TITLE
fix(alphanet): 🐞 wrong og description

### DIFF
--- a/pages/shardeum-liberty-alphanet/index.tsx
+++ b/pages/shardeum-liberty-alphanet/index.tsx
@@ -30,9 +30,9 @@ const AlphanetLanding: NextPage = () => {
         ]}
         openGraph={{
           url: "https://shardeum.org/shardeum-liberty-alphanet/",
-          title:
+          title: "Shardeum Liberty | Alphanet | Build your DApps and Web3 services on Shardeum",
+          description:
             "Shardeum is the world’s first layer 1 blockchain that truly solves scalability trilemma. It is an EVM based smart contract network that scales linearly with low gas fees forever with an aim to onboard billions of daily users and numerous DApps to Web 3",
-          description: "Open Graph Description",
           images: [
             {
               url: "https://shardeum.org/shardeum-liberty.jpeg",


### PR DESCRIPTION
### Problem / Change Summary

On the Alphanet page, The OG Description was a placeholder text so replaced it with the actual text. 

### Screenshot

Previous

<img width="401" alt="image" src="https://user-images.githubusercontent.com/36589645/167266072-87f4bb22-b5c2-4b5e-9d76-a60992cd68ed.png">

Now

<img width="377" alt="image" src="https://user-images.githubusercontent.com/36589645/167266088-a7698dbb-cab2-40ed-9882-891cde70140e.png">
