### PR TITLE
fix: 🐞 common components i18n breaking

### DIFF
--- a/pages/shardeum-liberty-alphanet/index.tsx
+++ b/pages/shardeum-liberty-alphanet/index.tsx
@@ -9,6 +9,7 @@ import Image from "next/image";
 import { AlphanetFeatureIcons } from "@shm/Icons";
 import { NextSeo } from "next-seo";
 import { DOCS_URL } from "constants/links";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 const AlphanetLanding: NextPage = () => {
   return (
@@ -215,6 +216,14 @@ const AlphanetLanding: NextPage = () => {
       <JoinCommunity />
     </>
   );
+};
+
+export const getStaticProps = async ({ locale }: { locale: string }) => {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["common"])),
+    },
+  };
 };
 
 export default AlphanetLanding;


### PR DESCRIPTION
The Alphanet page doesn't have translations added but the common components were expecting translation keys. That's why translation keys are showing on Navbar and Footer used on the Alphanet page

<img width="1884" alt="image" src="https://user-images.githubusercontent.com/36589645/168768081-094e0f40-2d9a-41a4-8353-ef4c26f317f5.png">
<img width="1884" alt="image" src="https://user-images.githubusercontent.com/36589645/168768088-4621c36e-87e1-43b8-8f6a-98c475168abd.png">
